### PR TITLE
removed acs-info module from fargate module

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ module "fargate-service" {
 | container_secrets | Map of secrets from the parameter store to be assigned to env variables. Use `task_policies` to make sure the Task's IAM role has access to the SSM parameters | {} |
 | vpc_id | ID of the VPC to deploy fargate service | |
 | subnet_ids | List of subnet IDs for the fargate service to be deployed into | |
-| target_groups | List of target group ARNs and their ports (`{arn=... port=...}`) to tie the service's containers to | |
+| target_groups | List of target groups to tie the service's containers to | |
 | load_balancer_sg_id | Load balancer's security group ID | |
 | task_policies | List of IAM Policy ARNs to attach to the task execution IAM Policy| [] |
 | task_cpu | CPU for the task definition | 256 |
@@ -52,10 +52,11 @@ module "fargate-service" {
 | role_permissions_boundary_arn | IAM Role Permission Boundary ARN to be added to IAM roles created | |
 | module_depends_on | Any resources that the fargate ecs service should wait on before initializing | null |
 
-**Note** the `target_groups` is a list of the target groups that can access your fargate containers. These target 
-groups must have the same port that your containers are listening on. For instance if your docker container is listening
-on port 8080 and 8443, you should have 2 target groups (and listeners), one mapped to port 8080 and the other to port 8443.
-This module will then map the Fargate service to listen on those ports to those target groups.
+**Note** the `target_groups` is a list of the target group objects (pass the objects from the aws target_group provider)
+that can access your fargate containers. These target groups must have the same port that your containers are listening 
+on. For instance if your docker container is listening on port 8080 and 8443, you should have 2 target groups (and 
+listeners), one mapped to port 8080 and the other to port 8443. This module will then map the Fargate service to listen 
+on those ports to those target groups.
 
 #### blue_green_deployment_config
 If this object is specified then this fargate service will only be deployable by CodeDeploy; meaning you can't update 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This terraform module deploys an AWS ECS Fargate Service
 ## Usage
 ```hcl
 module "fargate-service" {
-  source = "git@github.com:byu-oit/terraform-aws-fargate.git?ref=v1.0.0"
+  source = "git@github.com:byu-oit/terraform-aws-fargate.git?ref=v1.1.0"
   app_name        = "example"
     container_image = "crccheck/hello-world"
   
@@ -22,6 +22,7 @@ module "fargate-service" {
       }
     ]
   
+    role_permissions_boundary_arn = module.acs.role_permissions_boundary.arn
     module_depends_on = [module.alb.alb]
 }
 // ...
@@ -48,6 +49,7 @@ module "fargate-service" {
 | health_check_grace_period | Health check grace period in seconds | 0 |
 | blue_green_deployment_config | If you want this Fargate service to be deployed by CodeDeploy's Blue Green deployment, specify this object. See [below](#blue_green_deployment_config) | null |
 | tags | A map of AWS Tags to attach to each resource created | {} |
+| role_permissions_boundary_arn | IAM Role Permission Boundary ARN to be added to IAM roles created | |
 | module_depends_on | Any resources that the fargate ecs service should wait on before initializing | null |
 
 **Note** the `target_groups` is a list of the target groups that can access your fargate containers. These target 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ module "fargate-service" {
 // ...
 ```
 
+## Requirements
+* Terraform version 0.12.16 or greater
+
 ## Inputs
 
 | Name | Description | Default |

--- a/examples/simple/simple-example.tf
+++ b/examples/simple/simple-example.tf
@@ -1,12 +1,14 @@
 provider "aws" {
-  region = "us-west-2"
+  version = "~> 2.42"
+  region  = "us-west-2"
 }
 
-data "aws_caller_identity" "current" {}
-data "aws_region" "current" {}
-
+module "acs" {
+  source = "git@github.com:byu-oit/terraform-aws-acs-info.git?ref=v1.0.4"
+  env    = "dev"
+}
 module "simple_fargate" {
-      source = "git@github.com:byu-oit/terraform-aws-fargate.git?ref=v1.0.0"
+      source = "git@github.com:byu-oit/terraform-aws-fargate.git?ref=v1.1.0"
 //  source          = "../../" // used for local testing
   app_name        = "example"
   container_image = "crccheck/hello-world"
@@ -27,13 +29,8 @@ module "simple_fargate" {
     foo = "bar"
   }
 
+  role_permissions_boundary_arn = module.acs.role_permissions_boundary.arn
   module_depends_on = [module.alb.alb]
-}
-
-
-module "acs" {
-  source = "git@github.com:byu-oit/terraform-aws-acs-info.git?ref=v1.0.4"
-  env    = "dev"
 }
 
 module "alb" {

--- a/examples/simple/simple-example.tf
+++ b/examples/simple/simple-example.tf
@@ -8,21 +8,15 @@ module "acs" {
   env    = "dev"
 }
 module "simple_fargate" {
-      source = "git@github.com:byu-oit/terraform-aws-fargate.git?ref=v1.1.0"
-//  source          = "../../" // used for local testing
+  source = "git@github.com:byu-oit/terraform-aws-fargate.git?ref=v1.1.0"
+  //  source          = "../../" // used for local testing
   app_name        = "example"
   container_image = "crccheck/hello-world"
 
   vpc_id              = module.acs.vpc.id
   subnet_ids          = module.acs.private_subnet_ids
   load_balancer_sg_id = module.alb.alb_security_group.id
-  target_groups = [
-    for tg in module.alb.target_groups :
-    {
-      arn  = tg.arn
-      port = tg.port
-    }
-  ]
+  target_groups       = values(module.alb.target_groups)
 
   tags = {
     app = "example"
@@ -30,7 +24,7 @@ module "simple_fargate" {
   }
 
   role_permissions_boundary_arn = module.acs.role_permissions_boundary.arn
-  module_depends_on = [module.alb.alb]
+  module_depends_on             = [module.alb.alb]
 }
 
 module "alb" {

--- a/examples/with-codedeploy/with-codedeploy-example.tf
+++ b/examples/with-codedeploy/with-codedeploy-example.tf
@@ -1,12 +1,15 @@
 provider "aws" {
-  region = "us-west-2"
+  version = "~> 2.42"
+  region  = "us-west-2"
 }
 
-data "aws_caller_identity" "current" {}
-data "aws_region" "current" {}
+module "acs" {
+  source = "git@github.com:byu-oit/terraform-aws-acs-info.git?ref=v1.0.4"
+  env    = "dev"
+}
 
 module "simple_fargate" {
-        source = "git@github.com:byu-oit/terraform-aws-fargate.git?ref=v1.0.0"
+        source = "git@github.com:byu-oit/terraform-aws-fargate.git?ref=v1.1.0"
 //  source          = "../../" // used for local testing
   app_name        = "example2"
   container_name  = "simple-container"
@@ -37,6 +40,7 @@ module "simple_fargate" {
     test_traffic_listener_arns                     = []
     blue_target_group_name                         = module.alb.target_groups["blue"].name
     green_target_group_name                        = module.alb.target_groups["green"].name
+    service_role_arn                               = module.acs.power_builder_role.arn
   }
 
   tags = {
@@ -44,12 +48,8 @@ module "simple_fargate" {
     foo = "bar"
   }
 
+  role_permissions_boundary_arn = module.acs.role_permissions_boundary.arn
   module_depends_on = [module.alb.alb]
-}
-
-module "acs" {
-  source = "git@github.com:byu-oit/terraform-aws-acs-info.git?ref=v1.0.4"
-  env    = "dev"
 }
 
 module "alb" {

--- a/examples/with-codedeploy/with-codedeploy-example.tf
+++ b/examples/with-codedeploy/with-codedeploy-example.tf
@@ -9,14 +9,13 @@ module "acs" {
 }
 
 module "simple_fargate" {
-        source = "git@github.com:byu-oit/terraform-aws-fargate.git?ref=v1.1.0"
-//  source          = "../../" // used for local testing
+  source = "git@github.com:byu-oit/terraform-aws-fargate.git?ref=v1.1.0"
+  //  source          = "../../" // used for local testing
   app_name        = "example2"
   container_name  = "simple-container"
   container_image = "crccheck/hello-world"
   container_env_variables = {
     TEST_ENV = "foobar"
-    NEW_ENV  = "wasup"
   }
   container_secrets = {
     TEST_SECRET = aws_ssm_parameter.super_secret.name
@@ -26,13 +25,8 @@ module "simple_fargate" {
   vpc_id              = module.acs.vpc.id
   subnet_ids          = module.acs.private_subnet_ids
   load_balancer_sg_id = module.alb.alb_security_group.id
-  target_groups = [
-    {
-      arn  = module.alb.target_groups["blue"].arn
-      port = module.alb.target_groups["blue"].port
-    }
-  ]
-  task_policies = [aws_iam_policy.ssm_access.arn]
+  target_groups       = [module.alb.target_groups["blue"]]
+  task_policies       = [aws_iam_policy.ssm_access.arn]
 
   blue_green_deployment_config = {
     termination_wait_time_after_deployment_success = null // defaults to 15
@@ -49,7 +43,7 @@ module "simple_fargate" {
   }
 
   role_permissions_boundary_arn = module.acs.role_permissions_boundary.arn
-  module_depends_on = [module.alb.alb]
+  module_depends_on             = [module.alb.alb]
 }
 
 module "alb" {

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,8 @@
-module "acs" {
-  source = "git@github.com:byu-oit/terraform-aws-acs-info.git?ref=v1.0.4"
-  env    = "dev"
+terraform {
+  required_version = ">= 0.12.16"
+  required_providers {
+    aws = ">= 2.42"
+  }
 }
 
 data "aws_caller_identity" "current" {}
@@ -168,7 +170,7 @@ resource "aws_iam_role" "task_execution_role" {
   ]
 }
 EOF
-  permissions_boundary = module.acs.role_permissions_boundary.arn
+  permissions_boundary = var.role_permissions_boundary_arn
 
   tags = var.tags
 }
@@ -229,7 +231,7 @@ resource "aws_iam_role" "codedeploy_role" {
   count = local.is_deployed_by_codedeploy ? 1 : 0
 
   name                 = "${var.app_name}-codedeploy-role"
-  permissions_boundary = module.acs.role_permissions_boundary.arn
+  permissions_boundary = var.role_permissions_boundary_arn
   assume_role_policy   = <<EOF
 {
   "Version": "2012-10-17",
@@ -258,7 +260,7 @@ resource "aws_codedeploy_deployment_group" "deploymentgroup" {
 
   app_name               = aws_codedeploy_app.app[0].name
   deployment_group_name  = "${var.app_name}-deployment-group"
-  service_role_arn       = module.acs.power_builder_role.arn
+  service_role_arn       = var.blue_green_deployment_config.service_role_arn
   deployment_config_name = "CodeDeployDefault.ECSAllAtOnce"
 
   ecs_service {

--- a/variables.tf
+++ b/variables.tf
@@ -20,14 +20,11 @@ variable "load_balancer_sg_id" {
   description = "Load balancer's security group ID."
 }
 variable "target_groups" {
-  type = list(object({
-    arn  = string
-    port = number
-  }))
-  description = "List of target group ARNs and their ports."
+  type        = list(any)
+  description = "List of target groups. (use the provider object)"
 }
 variable "role_permissions_boundary_arn" {
-  type = string
+  type        = string
   description = "IAM Role Permission Boundary ARN to be added to IAM roles created."
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -26,6 +26,10 @@ variable "target_groups" {
   }))
   description = "List of target group ARNs and their ports."
 }
+variable "role_permissions_boundary_arn" {
+  type = string
+  description = "IAM Role Permission Boundary ARN to be added to IAM roles created."
+}
 
 // Optional
 variable "desired_count" {
@@ -81,6 +85,7 @@ variable "blue_green_deployment_config" {
     test_traffic_listener_arns                     = list(string)
     blue_target_group_name                         = string
     green_target_group_name                        = string
+    service_role_arn                               = string
   })
   description = "CodeDeploy Blue Green deployment configuration. Defaults to `null`"
   default     = null


### PR DESCRIPTION
now requires permissions_boundary_arn variable and power_build_role_arn variable (if blue-green is configured).

This is more in line with Terraform's recommendations regarding nested modules.

This would probably be release v1.1.0